### PR TITLE
Updated istanbul to version 0.3.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "1.6.0",
     "eslint-config-springworks": "3.2.0",
     "eslint-plugin-mocha": "1.0.0",
-    "istanbul": "0.3.21",
+    "istanbul": "0.3.22",
     "mocha": "2.3.3"
   },
   "repository": {


### PR DESCRIPTION
:rocket:

istanbul just published version 0.3.22, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [2a6d054](https://github.com/gotwarlost/istanbul/commit/2a6d054a3ae5b1582000b4c84ce16577a471c713): 0.3.22
- [d445edd](https://github.com/gotwarlost/istanbul/commit/d445edda914e71cbbc561e1fcaea977277dab9d5): Merge pull request #455 from sterlinghw/master
- [eebd2aa](https://github.com/gotwarlost/istanbul/commit/eebd2aadea6e020d01fa5dcc78095dd13b3a04e3): update escodegen to its latest version, reenabling support for super()

See the [full diff](https://github.com/gotwarlost/istanbul/compare/5e87c9cce3939bb49f303406d0a630649c604fc8...2a6d054a3ae5b1582000b4c84ce16577a471c713).
